### PR TITLE
Fix issue where query params would not be properly url-encoded

### DIFF
--- a/BadgeUpClient.Tests/HttpQueryTest.cs
+++ b/BadgeUpClient.Tests/HttpQueryTest.cs
@@ -1,7 +1,4 @@
-using System;
-using BadgeUp.Http;
-using BadgeUp.ResourceClients;
-using BadgeUp.Types;
+﻿using BadgeUp.Http;
 using Xunit;
 
 namespace BadgeUp.Tests
@@ -9,13 +6,50 @@ namespace BadgeUp.Tests
 	public class HttpQueryTest
 	{
 		[Fact]
-		public void HttpQuery_ToString()
+		public void MultipleParameterPairs_ToString_ConcatenatesPairs()
 		{
 			var query = new HttpQuery();
-			query.Add( "key1", "value1" );
-			query.Add( "key2", "value2" );
+			query.Add("key1", "value1");
+			query.Add("key2", "value2");
 
-			Assert.Equal( "key1=value1&key2=value2", query.ToString() );
+			Assert.Equal("key1=value1&key2=value2", query.ToString());
+		}
+
+		[Fact]
+		public void MultipleParameterPairs_ToString_DoesntProduceTrailingAmpersand()
+		{
+			var query = new HttpQuery();
+			query.Add("key1", "value1");
+			query.Add("key2", "value2");
+
+			Assert.False(query.ToString().EndsWith("&"));
+		}
+
+		[Fact]
+		public void ToString_UrlEncodesParameterKeysAndValues()
+		{
+			var query = new HttpQuery();
+			query.Add("key 1", "value 1");
+
+			Assert.Equal("key%201=value%201", query.ToString());
+		}
+
+		[Fact]
+		public void ToString_UrlEncodesEmojiAndUnicodeKeysAndValues()
+		{
+			var query = new HttpQuery();
+			query.Add("🔥key🔥", "тест 🔥value🔥 тест");
+
+			Assert.Equal("%F0%9F%94%A5key%F0%9F%94%A5=%D1%82%D0%B5%D1%81%D1%82%20%F0%9F%94%A5value%F0%9F%94%A5%20%D1%82%D0%B5%D1%81%D1%82", query.ToString());
+		}
+
+		[Fact]
+		public void ToString_UrlEncodesSpecialSymbolsInKeysAndValues()
+		{
+			var query = new HttpQuery();
+			query.Add("key=", "value=");
+
+			Assert.Equal("key%3D=value%3D", query.ToString());
 		}
 	}
 }

--- a/BadgeUpClient.Tests/QueryParamTests.cs
+++ b/BadgeUpClient.Tests/QueryParamTests.cs
@@ -14,14 +14,14 @@ namespace BadgeUp.Tests
 				AchievementId = "foo",
 				Since = new DateTime(2000, 1, 1),
 				Until = new DateTime(2001, 1, 1),
-				Subject = "bar"
+				Subject = "bar 1 2=3"
 			};
 			var res = param.ToQueryString();
 
-			Assert.Contains("subject=bar", res);
+			Assert.Contains("subject=bar%201%202%3D3", res);
 			Assert.Contains("achievementId=foo", res);
-			Assert.Contains("since=2000-01-01T00:00:00", res);
-			Assert.Contains("until=2001-01-01T00:00:00", res);
+			Assert.Contains("since=2000-01-01T00%3A00%3A00", res);
+			Assert.Contains("until=2001-01-01T00%3A00%3A00", res);
 		}
 	}
 }

--- a/BadgeUpClient.Tests/ResourceClients/MetricClientTests.cs
+++ b/BadgeUpClient.Tests/ResourceClients/MetricClientTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using BadgeUp.Http;
+using BadgeUp.ResourceClients;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace BadgeUp.Tests
+{
+	public class MetricClientTests
+	{
+		[Fact]
+		public async Task WhenSubjectAndKeyContainRestrictedCharacters_GetIndividualBySubject_UrlEncodesRestrictedCharacters()
+		{
+			// Setup mock expectation for a encoded url call
+			var mockHttpHandler = new MockHttpMessageHandler();
+			mockHttpHandler.Expect(HttpMethod.Get, "https://api.useast1.badgeup.io/v1/apps/1337/metrics/test%3Asubject%3D123/testKey%20123").Respond("application/json", "{}");
+			using (var badgeUpClient = new BadgeUpHttpClient(ApiKey.Create("eyJhY2NvdW50SWQiOiJ0aGViZXN0IiwiYXBwbGljYXRpb25JZCI6IjEzMzciLCJrZXkiOiJpY2VjcmVhbWFuZGNvb2tpZXN5dW0ifQ=="), "https://api.useast1.badgeup.io"))
+			{
+				badgeUpClient._SetHttpClient(mockHttpHandler.ToHttpClient());
+
+				// pass subject and key with restricted characters
+				var metricClient = new MetricClient(badgeUpClient);
+				var metric = await metricClient.GetIndividualBySubject("test:subject=123", "testKey 123");
+			}
+
+			// expect encoded url to have been called
+			mockHttpHandler.VerifyNoOutstandingExpectation();
+		}
+	}
+}

--- a/BadgeUpClient/Encoding/UrlEncoder.cs
+++ b/BadgeUpClient/Encoding/UrlEncoder.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace BadgeUpClient.Encoding
+{
+	/// <summary>
+	/// Represents a common helper class to encode strings like URI params.
+	/// </summary>
+	internal static class EncodingExtensions
+	{
+		/// <summary>
+		/// Converts a text string into a URL-encoded string.
+		/// </summary>
+		/// <param name="stringToEncode">String to encode.</param>
+		/// <returns>Returns the encoded string.</returns>
+		public static string UrlEncode(this string stringToEncode) => Uri.EscapeDataString(stringToEncode);
+
+		/// <summary>
+		/// Converts an object into a URL-encoded string by using the object's .ToString() implementation.
+		/// </summary>
+		/// <param name="objectToEncode">Object to encode.</param>
+		/// <returns>Returns the encoded string.</returns>
+		public static string UrlEncode(this object objectToEncode) => objectToEncode?.ToString()?.UrlEncode();
+	}
+}

--- a/BadgeUpClient/Http/HttpQuery.cs
+++ b/BadgeUpClient/Http/HttpQuery.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BadgeUp.ResourceClients;
+using BadgeUpClient.Encoding;
 
 namespace BadgeUp.Http
 {
 	public class HttpQuery
 	{
 		List<KeyValuePair<string, string>> m_values = new List<KeyValuePair<string, string>>();
-
 
 		public void Add<T>( string name, T value )
 		{
@@ -20,7 +20,7 @@ namespace BadgeUp.Http
 		{
 			if (m_values.Count > 0)
 			{
-				return m_values.Select( a => a.Key + '=' + a.Value ).Aggregate( ( a, b ) => a + "&" + b );
+				return m_values.Select( a => a.Key.UrlEncode() + '=' + a.Value.UrlEncode() ).Aggregate( ( a, b ) => a + "&" + b );
 			}
 
 			return null;

--- a/BadgeUpClient/ResourceClients/MetricClient.cs
+++ b/BadgeUpClient/ResourceClients/MetricClient.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using BadgeUp.Http;
 using BadgeUp.Responses;
+using BadgeUpClient.Encoding;
 
 namespace BadgeUp.ResourceClients
 {
@@ -23,7 +24,7 @@ namespace BadgeUp.ResourceClients
 		/// <returns><see cref="MetricResponse"/></returns>
 		public async Task<MetricResponse> GetIndividualBySubject(string subjectId, string key)
 		{
-			return await this.m_httpClient.Get<MetricResponse>(ENDPOINT + "/" + subjectId + "/" + key);
+			return await this.m_httpClient.Get<MetricResponse>(ENDPOINT + "/" + subjectId.UrlEncode() + "/" + key.UrlEncode());
 		}
 
 

--- a/BadgeUpClient/Types/QueryParams.cs
+++ b/BadgeUpClient/Types/QueryParams.cs
@@ -1,3 +1,4 @@
+using BadgeUpClient.Encoding;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -12,7 +13,7 @@ namespace BadgeUp.Types
 				.GetTypeInfo()
 				.GetProperties()
 				.Where(p => p.GetValue(this, null) != null)
-				.Select(p => FirstCharacterToLower(p.Name) + "=" + (p.PropertyType == typeof(DateTime?) ? ((DateTime?)p.GetValue(this, null)).Value.ToString("O") : p.GetValue(this, null)).ToString());
+				.Select(p => FirstCharacterToLower(p.Name).UrlEncode() + "=" + (p.PropertyType == typeof(DateTime?) ? ((DateTime?)p.GetValue(this, null)).Value.ToString("O") : p.GetValue(this, null)).ToString().UrlEncode());
 
 			return String.Join("&", properties.ToArray());
 		}


### PR DESCRIPTION
* Add tests for checking if `HttpQuery` encodes properly when calling `.ToString()`
* Add tests for checking if `QueryParams` encodes properly when calling `.ToQueryParams()`.
* Add tests for checking if `MetricClient` encodes its given parameters before sending to the server.
* Add common `string` and `object` extension methods for simplifying URL encoding.