### PR TITLE
Fix issue where JSON-serializing enums would return an int instead of string

### DIFF
--- a/BadgeUpClient.Tests/SerializationTest.cs
+++ b/BadgeUpClient.Tests/SerializationTest.cs
@@ -274,6 +274,15 @@ namespace BadgeUp.Tests
 			}";
 
 		[Fact]
+		public void Serialization_EarnedAwardStateSerialize()
+		{
+			Assert.Equal("\"created\"", Json.Serialize(EarnedAwardState.Created));
+			Assert.Equal("\"approved\"", Json.Serialize(EarnedAwardState.Approved));
+			Assert.Equal("\"rejected\"", Json.Serialize(EarnedAwardState.Rejected));
+			Assert.Equal("\"redeemed\"", Json.Serialize(EarnedAwardState.Redeemed));
+		}
+
+		[Fact]
 		public void Serialization_EarnedAwardDeserialize()
 		{
 			var award = Json.Deserialize<EarnedAwardResponse>(earnedAwardJson);
@@ -413,6 +422,16 @@ namespace BadgeUp.Tests
 					}
 				}
 			}";
+
+		[Fact]
+		public void Serialization_CriterionOperatorSerialize()
+		{
+			Assert.Equal("\"@gt\"", Json.Serialize(CriterionOperator.Greater));
+			Assert.Equal("\"@gte\"", Json.Serialize(CriterionOperator.GreaterOrEqual));
+			Assert.Equal("\"@lt\"", Json.Serialize(CriterionOperator.Less));
+			Assert.Equal("\"@lte\"", Json.Serialize(CriterionOperator.LessOrEqual));
+			Assert.Equal("\"@eq\"", Json.Serialize(CriterionOperator.Equal));
+		}
 
 		[Fact]
 		public void Serialization_CriterionDeserialize()

--- a/BadgeUpClient/Json.cs
+++ b/BadgeUpClient/Json.cs
@@ -18,7 +18,7 @@ namespace BadgeUp
 				new JsonSerializerSettings
 				{
 					ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver(),
-					Converters = new List<JsonConverter>() {new StringEnumConverter {CamelCaseText = true}}
+					Converters = new List<JsonConverter>() { new StringEnumConverter { CamelCaseText = true } }
 				});
 		}
 
@@ -29,7 +29,8 @@ namespace BadgeUp
 				new JsonSerializerSettings
 				{
 					ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver(),
-					NullValueHandling = NullValueHandling.Ignore
+					NullValueHandling = NullValueHandling.Ignore,
+					Converters = new List<JsonConverter>() { new StringEnumConverter { CamelCaseText = true } }
 				});
 		}
 	}


### PR DESCRIPTION
`JSON.Serialize()` and `.Deserialize()` have different options regarding enum<->string conversion, which causes an issue when serializing requests with enums inside of the request payload.
For example, serializing `CriterionOperator.Equal` would return `4` instead of `"@eq"`.
This PR unifies the options and adds regression tests.