### PR TITLE
Move certain BadgeUp.Responses classes to BadgeUp.Types

### DIFF
--- a/BadgeUpClient/Responses/AchievementResponse.cs
+++ b/BadgeUpClient/Responses/AchievementResponse.cs
@@ -21,14 +21,4 @@ namespace BadgeUp.Responses
 		public List<CriterionResponse> Criteria { get; set; }
 		public List<AwardResponse> Awards { get; set; }
 	}
-
-	public class AchievementMeta : Meta
-	{
-		public string Icon { get; set; }
-	}
-
-	public class AchievementOptions
-	{
-		public bool Suspended { get; set; } = false;
-	}
 }

--- a/BadgeUpClient/Responses/ApplicationResponse.cs
+++ b/BadgeUpClient/Responses/ApplicationResponse.cs
@@ -10,9 +10,4 @@ namespace BadgeUp.Responses
 		public string Description { get; set; }
 		public ApplicationMeta Meta { get; set; }
 	}
-
-	public class ApplicationMeta : Meta
-	{
-		public bool Demo { get; set; }
-	}
 }

--- a/BadgeUpClient/Responses/CriterionResponse.cs
+++ b/BadgeUpClient/Responses/CriterionResponse.cs
@@ -13,25 +13,4 @@ namespace BadgeUp.Responses
 		public Meta Meta { get; set; }
 		public CriterionEvaluation Evaluation { get; set; }
 	}
-
-	public class CriterionEvaluation
-	{
-		public string Type { get; set; }
-		public CriterionOperator Operator { get; set; }
-		public int Threshold { get; set; }
-	}
-
-	public enum CriterionOperator
-	{
-		[EnumMember(Value = "@gt")]
-		Greater,
-		[EnumMember(Value = "@gte")]
-		GreaterOrEqual,
-		[EnumMember(Value = "@lt")]
-		Less,
-		[EnumMember(Value = "@lte")]
-		LessOrEqual,
-		[EnumMember(Value = "@eq")]
-		Equal
-	}
 }

--- a/BadgeUpClient/Types/AchievementMeta.cs
+++ b/BadgeUpClient/Types/AchievementMeta.cs
@@ -1,0 +1,7 @@
+namespace BadgeUp.Types
+{
+	public class AchievementMeta : Meta
+	{
+		public string Icon { get; set; }
+	}
+}

--- a/BadgeUpClient/Types/AchievementOptions.cs
+++ b/BadgeUpClient/Types/AchievementOptions.cs
@@ -1,0 +1,7 @@
+namespace BadgeUp.Types
+{
+	public class AchievementOptions
+	{
+		public bool Suspended { get; set; } = false;
+	}
+}

--- a/BadgeUpClient/Types/ApplicationMeta.cs
+++ b/BadgeUpClient/Types/ApplicationMeta.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BadgeUp.Types
+{
+	public class ApplicationMeta : Meta
+	{
+		public bool Demo { get; set; }
+	}
+}

--- a/BadgeUpClient/Types/CriterionEvaluation.cs
+++ b/BadgeUpClient/Types/CriterionEvaluation.cs
@@ -1,0 +1,9 @@
+﻿namespace BadgeUp.Types
+{
+	public class CriterionEvaluation
+	{
+		public string Type { get; set; }
+		public CriterionOperator Operator { get; set; }
+		public int Threshold { get; set; }
+	}
+}

--- a/BadgeUpClient/Types/CriterionOperator.cs
+++ b/BadgeUpClient/Types/CriterionOperator.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.Serialization;
+
+namespace BadgeUp.Types
+{
+	public enum CriterionOperator
+	{
+		[EnumMember(Value = "@gt")]
+		Greater,
+		[EnumMember(Value = "@gte")]
+		GreaterOrEqual,
+		[EnumMember(Value = "@lt")]
+		Less,
+		[EnumMember(Value = "@lte")]
+		LessOrEqual,
+		[EnumMember(Value = "@eq")]
+		Equal
+	}
+}


### PR DESCRIPTION
Some classes like `ApplicationMeta`, `AchievementMeta` and `CriterionEvaluation` are currently in the `BadgeUp.Responses` namespace.
If we want to use these classes in requests (i.e. if an `Achievement` or an `AchievementRequest` contains an `AchievementMeta`), we'll need to reference the `BadgeUp.Responses` namespace from `BadgeUp.Requests` or `BadgeUp.Types`, which is an incorrect dependency.