### PR TITLE
Force Visual Studio 2017 to format code in solution using tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,6 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{cs}]
+[*.cs]
 charset = utf-8
 indent_style = tab


### PR DESCRIPTION
VS 2017 on Windows doesn't recognize the need to format code using tabs and instead uses the default IDE setting, which causes issue with autoformatting (mixing spaces & tabs).