### PR TITLE
Add support for creating a metric and getting all metrics for a subject

### DIFF
--- a/BadgeUpClient.Tests/ResourceClients/MetricClientTests.cs
+++ b/BadgeUpClient.Tests/ResourceClients/MetricClientTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using BadgeUp.Http;
@@ -9,6 +10,13 @@ namespace BadgeUp.Tests
 {
 	public class MetricClientTests
 	{
+		[Fact]
+		public async Task WhenMetricIsNull_CreateThrowsException()
+		{
+			var client = new MetricClient(null);
+			await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null));
+		}
+
 		[Fact]
 		public async Task WhenSubjectAndKeyContainRestrictedCharacters_GetIndividualBySubject_UrlEncodesRestrictedCharacters()
 		{

--- a/BadgeUpClient.Tests/ResourceClients/MetricClientTests.cs
+++ b/BadgeUpClient.Tests/ResourceClients/MetricClientTests.cs
@@ -22,7 +22,14 @@ namespace BadgeUp.Tests
 		{
 			// Setup mock expectation for a encoded url call
 			var mockHttpHandler = new MockHttpMessageHandler();
-			mockHttpHandler.Expect(HttpMethod.Get, "https://api.useast1.badgeup.io/v2/apps/1337/metrics/test%3Asubject%3D123/testKey%20123").Respond("application/json", "{}");
+			var response = @"{
+				'id': 'ca98dfajl3kja9kjh34589734',
+				'applicationId': 'ci123doiu3',
+				'key': 'testKey 123',
+				'subject': 'test:subject=123',
+				'value': 5
+			}".Replace("'", "\"");
+			mockHttpHandler.Expect(HttpMethod.Get, "https://api.useast1.badgeup.io/v2/apps/1337/metrics/test%3Asubject%3D123/testKey%20123").Respond("application/json", response);
 			using (var badgeUpClient = new BadgeUpHttpClient(ApiKey.Create("eyJhY2NvdW50SWQiOiJ0aGViZXN0IiwiYXBwbGljYXRpb25JZCI6IjEzMzciLCJrZXkiOiJpY2VjcmVhbWFuZGNvb2tpZXN5dW0ifQ=="), "https://api.useast1.badgeup.io"))
 			{
 				badgeUpClient._SetHttpClient(mockHttpHandler.ToHttpClient());
@@ -30,6 +37,63 @@ namespace BadgeUp.Tests
 				// pass subject and key with restricted characters
 				var metricClient = new MetricClient(badgeUpClient);
 				var metric = await metricClient.GetIndividualBySubject("test:subject=123", "testKey 123");
+				Assert.Equal("test:subject=123", metric.Subject);
+				Assert.Equal("testKey 123", metric.Key);
+			}
+
+			// expect encoded url to have been called
+			mockHttpHandler.VerifyNoOutstandingExpectation();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndKeyContainRestrictedCharacters_GetAllBySubject_UrlEncodesRestrictedCharacters()
+		{
+			// Setup mock expectation for a encoded url call
+			var mockHttpHandler = new MockHttpMessageHandler();
+			var response = @"{
+				'pages': {
+					'previous': null,
+					'next': null
+				},
+				'data': [
+					{
+						'id': 'cja8a0980j3jkajhaaa345810',
+						'applicationId': 'e7kmr6m0ob',
+						'key': 'test',
+						'subject': 'test:subject=123',
+						'value': 5
+					},
+					{
+						'id': 'cjmx29083hjkaaa325usgaitx',
+						'applicationId': 'e7kmr6m0ob',
+						'key': 'test:key',
+						'subject': 'test:subject=123',
+						'value': 1
+					},
+					{
+						'id': 'cjmy215tq87hdo1b9hrb2qlsj',
+						'applicationId': 'e7kmr6m0ob',
+						'key': 'test:metric',
+						'subject': 'test:subject=123',
+						'value': 5
+					}
+				]
+			}".Replace("'","\"");
+			mockHttpHandler.Expect(HttpMethod.Get, "https://api.useast1.badgeup.io/v2/apps/1337/metrics/test%3Asubject%3D123").Respond("application/json", response);
+			using (var badgeUpClient = new BadgeUpHttpClient(ApiKey.Create("eyJhY2NvdW50SWQiOiJ0aGViZXN0IiwiYXBwbGljYXRpb25JZCI6IjEzMzciLCJrZXkiOiJpY2VjcmVhbWFuZGNvb2tpZXN5dW0ifQ=="), "https://api.useast1.badgeup.io"))
+			{
+				badgeUpClient._SetHttpClient(mockHttpHandler.ToHttpClient());
+
+				// pass subject and key with restricted characters
+				var metricClient = new MetricClient(badgeUpClient);
+				var metrics = await metricClient.GetAllBySubject("test:subject=123");
+				Assert.Equal(3, metrics.Count);
+				Assert.Equal("test:subject=123", metrics[0].Subject);
+				Assert.Equal("test:subject=123", metrics[1].Subject);
+				Assert.Equal("test:subject=123", metrics[2].Subject);
+				Assert.Equal("test", metrics[0].Key);
+				Assert.Equal("test:key", metrics[1].Key);
+				Assert.Equal("test:metric", metrics[2].Key);
 			}
 
 			// expect encoded url to have been called

--- a/BadgeUpClient.Tests/integration/MetricsIntegration.cs
+++ b/BadgeUpClient.Tests/integration/MetricsIntegration.cs
@@ -13,6 +13,11 @@ namespace BadgeUp.Tests
 	{
 		private readonly string API_KEY = IntegrationApiKey.Get();
 
+		private string RandomSubject()
+		{
+			return "dotnet-ci-" + Guid.NewGuid().ToString("N");
+		}
+
 		[SkippableFact]
 		public async Task MetricsIntegration_GetAll()
 		{
@@ -97,19 +102,19 @@ namespace BadgeUp.Tests
 				throw new SkipException("Tests skipped on environments without API_KEY variable configured");
 
 			var client = new BadgeUpClient(this.API_KEY);
-
+			var subject = this.RandomSubject();
 			// Create a new metric
 			var result = await client.Metric.Create(new Metric()
 			{
 				Key = "test:metric",
-				Subject = "randomsubject",
+				Subject = subject,
 				Value = 5
 			});
 
 			// Verify the metric has been created with the same parameters
 			Assert.NotNull(result);
 			Assert.Equal("test:metric", result.Key);
-			Assert.Equal("randomsubject", result.Subject);
+			Assert.Equal(subject, result.Subject);
 			Assert.Equal(5, result.Value);
 
 			// Verify we can get the metric by id.
@@ -117,7 +122,7 @@ namespace BadgeUp.Tests
 			Assert.NotNull(metric);
 
 			Assert.Equal("test:metric", metric.Key);
-			Assert.Equal("randomsubject", metric.Subject);
+			Assert.Equal(subject, metric.Subject);
 			Assert.Equal(5, metric.Value);
 
 			// TODO: Delete the metric

--- a/BadgeUpClient.Tests/integration/MetricsIntegration.cs
+++ b/BadgeUpClient.Tests/integration/MetricsIntegration.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BadgeUp.Tests;
+using BadgeUp.Types;
+using Xunit;
+
+namespace BadgeUp.Tests
+{
+	public class MetricsIntegration
+	{
+		private readonly string API_KEY = IntegrationApiKey.Get();
+
+		[SkippableFact]
+		public async Task MetricsIntegration_GetAll()
+		{
+			if (string.IsNullOrEmpty(this.API_KEY))
+				throw new SkipException("Tests skipped on environments without API_KEY variable configured");
+
+			var client = new BadgeUpClient(this.API_KEY);
+
+			var metrics = await client.Metric.GetAll();
+			Assert.NotEmpty(metrics);
+		}
+
+		[SkippableFact]
+		public async Task MetricsIntegration_GetAllBySubject()
+		{
+			if (string.IsNullOrEmpty(this.API_KEY))
+				throw new SkipException("Tests skipped on environments without API_KEY variable configured");
+
+			var client = new BadgeUpClient(this.API_KEY);
+
+			// Verify we have any metrics.
+			var allMetrics = await client.Metric.GetAll();
+			Assert.NotEmpty(allMetrics);
+
+			// Get the metrics for a subject.
+			var groupedMetrics = allMetrics.GroupBy(m => m.Subject).OrderByDescending(ig => ig.Count()).ToList();
+			var subject = groupedMetrics.FirstOrDefault()?.Key;
+			var metricsForTestedSubject = groupedMetrics.FirstOrDefault().ToList();
+			Assert.NotNull(subject);
+			Assert.NotEmpty(metricsForTestedSubject);
+
+			var result = await client.Metric.GetAllBySubject(subject);
+
+			// Verify the result
+			Assert.NotNull(result);
+			Assert.NotSame(metricsForTestedSubject, result);
+			Assert.Equal(metricsForTestedSubject.Count(), result.Count());
+
+			for (int i = 0; i < metricsForTestedSubject.Count(); i++)
+			{
+				var expectedMetric = metricsForTestedSubject[i];
+				var actualMetric = result[i];
+
+				Assert.Equal(expectedMetric.Id, actualMetric.Id);
+				Assert.Equal(expectedMetric.ApplicationId, actualMetric.ApplicationId);
+				Assert.Equal(expectedMetric.Key, actualMetric.Key);
+				Assert.Equal(expectedMetric.Subject, actualMetric.Subject);
+				Assert.Equal(expectedMetric.Value, actualMetric.Value);
+			}
+		}
+
+		[SkippableFact]
+		public async Task MetricsIntegration_GetIndividualBySubject()
+		{
+			if (string.IsNullOrEmpty(this.API_KEY))
+				throw new SkipException("Tests skipped on environments without API_KEY variable configured");
+
+			var client = new BadgeUpClient(this.API_KEY);
+
+			// Verify we have any metrics.
+			var allMetrics = await client.Metric.GetAll();
+			Assert.NotEmpty(allMetrics);
+
+			// Get the first metric.
+			var firstMetric = allMetrics.First();
+			var result = await client.Metric.GetIndividualBySubject(firstMetric.Subject, firstMetric.Key);
+
+			// Verify the result
+			Assert.NotNull(result);
+			Assert.NotSame(firstMetric, result);
+			Assert.Equal(firstMetric.Id, result.Id);
+			Assert.Equal(firstMetric.ApplicationId, result.ApplicationId);
+			Assert.Equal(firstMetric.Key, result.Key);
+			Assert.Equal(firstMetric.Subject, result.Subject);
+			Assert.Equal(firstMetric.Value, result.Value);
+		}
+
+		[SkippableFact]
+		public async Task MetricsIntegration_Create()
+		{
+			if (string.IsNullOrEmpty(this.API_KEY))
+				throw new SkipException("Tests skipped on environments without API_KEY variable configured");
+
+			var client = new BadgeUpClient(this.API_KEY);
+
+			// Create a new metric
+			var result = await client.Metric.Create(new Metric()
+			{
+				Key = "test:metric",
+				Subject = "randomsubject",
+				Value = 5
+			});
+
+			// Verify the metric has been created with the same parameters
+			Assert.NotNull(result);
+			Assert.Equal("test:metric", result.Key);
+			Assert.Equal("randomsubject", result.Subject);
+			Assert.Equal(5, result.Value);
+
+			// Verify we can get the metric by id.
+			var metric = await client.Metric.GetIndividualBySubject(result.Subject, "test:metric");
+			Assert.NotNull(metric);
+
+			Assert.Equal("test:metric", metric.Key);
+			Assert.Equal("randomsubject", metric.Subject);
+			Assert.Equal(5, metric.Value);
+
+			// TODO: Delete the metric
+			// TODO: Verify deletion has completed successfully.
+		}
+	}
+}

--- a/BadgeUpClient/Requests/MetricRequest.cs
+++ b/BadgeUpClient/Requests/MetricRequest.cs
@@ -1,0 +1,19 @@
+using BadgeUp.Types;
+
+namespace BadgeUp.Requests
+{
+	public class MetricRequest : Request
+	{
+		public MetricRequest(Metric metric)
+		{
+			this.Metric = metric;
+		}
+
+		public Metric Metric { get; }
+
+		public override string ToJson()
+		{
+			return Json.Serialize(this.Metric);
+		}
+	}
+}

--- a/BadgeUpClient/ResourceClients/MetricClient.cs
+++ b/BadgeUpClient/ResourceClients/MetricClient.cs
@@ -3,6 +3,9 @@ using System.Threading.Tasks;
 using BadgeUp.Http;
 using BadgeUp.Responses;
 using BadgeUp.Extensions;
+using BadgeUp.Requests;
+using BadgeUp.Types;
+using System;
 
 namespace BadgeUp.ResourceClients
 {
@@ -27,7 +30,6 @@ namespace BadgeUp.ResourceClients
 			return await this.m_httpClient.Get<MetricResponse>(ENDPOINT + "/" + subjectId.UrlEncode() + "/" + key.UrlEncode());
 		}
 
-
 		/// <summary>
 		/// Retrieves a list of all metrics.
 		/// </summary>
@@ -35,6 +37,36 @@ namespace BadgeUp.ResourceClients
 		public async Task<List<MetricResponse>> GetAll()
 		{
 			return await this.m_httpClient.GetAll<MetricResponse>(ENDPOINT);
+		}
+
+		/// <summary>
+		/// Retrieves a list of metrics for a single subject.
+		/// </summary>
+		/// <param name="subjectId">Unique subject the metrics is associated with.</param>
+		/// <returns></returns>
+		public async Task<List<MetricResponse>> GetAllBySubject(string subjectId)
+		{
+			var result = await this.m_httpClient.GetAll<MetricResponse>(ENDPOINT + "/" + subjectId);
+			return result;
+		}
+
+		/// <summary>
+		/// Creates a single metric.
+		/// </summary>
+		/// <param name="key">States what the metric represents, such as a player action or other occurrence. You may want to create your keys in groups, e.g. "player:jump".</param>
+		/// <param name="subject">Identifies the subject this metric is for. This would commonly be a unique user identifier.</param>
+		/// <param name="value">Value of this metric.</param>
+		/// <returns></returns>
+		public async Task<MetricResponse> Create(Metric metric)
+		{
+			if (metric == null)
+			{
+				throw new ArgumentNullException(nameof(metric));
+			}
+
+			var request = new MetricRequest(metric);
+
+			return await this.m_httpClient.Post<MetricResponse>(request, ENDPOINT + "/" + metric.Subject);
 		}
 	}
 }

--- a/BadgeUpClient/ResourceClients/MetricClient.cs
+++ b/BadgeUpClient/ResourceClients/MetricClient.cs
@@ -46,8 +46,7 @@ namespace BadgeUp.ResourceClients
 		/// <returns></returns>
 		public async Task<List<MetricResponse>> GetAllBySubject(string subjectId)
 		{
-			var result = await this.m_httpClient.GetAll<MetricResponse>(ENDPOINT + "/" + subjectId);
-			return result;
+			return await this.m_httpClient.GetAll<MetricResponse>(ENDPOINT + "/" + subjectId.UrlEncode());
 		}
 
 		/// <summary>
@@ -66,7 +65,7 @@ namespace BadgeUp.ResourceClients
 
 			var request = new MetricRequest(metric);
 
-			return await this.m_httpClient.Post<MetricResponse>(request, ENDPOINT + "/" + metric.Subject);
+			return await this.m_httpClient.Post<MetricResponse>(request, ENDPOINT + "/" + metric.Subject.UrlEncode());
 		}
 	}
 }

--- a/BadgeUpClient/Responses/MetricResponse.cs
+++ b/BadgeUpClient/Responses/MetricResponse.cs
@@ -8,5 +8,4 @@ namespace BadgeUp.Responses
 		public string Subject { get; set; }
 		public int Value { get; set; }
 	}
-
 }

--- a/BadgeUpClient/Types/Metric.cs
+++ b/BadgeUpClient/Types/Metric.cs
@@ -1,0 +1,9 @@
+namespace BadgeUp.Types
+{
+	public class Metric
+	{
+		public string Key { get; set; }
+		public string Subject { get; set; }
+		public int Value { get; set; }
+	}
+}


### PR DESCRIPTION
Implement `/v1/apps/:applicationId/metrics/:subject` and `/v2/apps/:applicationId/metrics/:subjectId/:key` as `MetricClient.GetAllBySubject()` and `MetricClient.Create()`.