### PR TITLE
Make async/await usage consistent with .NET guidelines

### DIFF
--- a/BadgeUpClient/Http/BadgeUpHttpClient.cs
+++ b/BadgeUpClient/Http/BadgeUpHttpClient.cs
@@ -35,9 +35,9 @@ namespace BadgeUp.Http
 			{
 				try
 				{
-					var response = await m_httpClient.GetAsync(
-						m_host + path.TrimEnd('/') + "/" + endpointName.TrimStart('/') + (query != null ? '?' + query : ""));
-					responseContent = await response.Content.ReadAsStringAsync();
+					var requestUri = m_host + path.TrimEnd('/') + "/" + endpointName.TrimStart('/') + (query != null ? '?' + query : "");
+					var response = await m_httpClient.GetAsync(requestUri).ConfigureAwait(false);
+					responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
 					if (response.IsSuccessStatusCode)
 					{
@@ -64,7 +64,7 @@ namespace BadgeUp.Http
 			string url = endpoint;
 			do
 			{
-				var response = await this.Get<MultipleResponse<TResponse>>(url, path, query);
+				var response = await this.Get<MultipleResponse<TResponse>>(url, path, query).ConfigureAwait(false);
 				result.AddRange(response.Data);
 				url = response.Pages?.Next;
 
@@ -94,10 +94,9 @@ namespace BadgeUp.Http
 			{
 				try
 				{
-					var response = await m_httpClient.PostAsync(
-						m_host + path + "/" + endpointName + (query != null ? '?' + query : ""),
-						content);
-					responseContent = await response.Content.ReadAsStringAsync();
+					var requestUri = m_host + path + "/" + endpointName + (query != null ? '?' + query : "");
+					var response = await m_httpClient.PostAsync(requestUri,content).ConfigureAwait(false);
+					responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
 					if (response.IsSuccessStatusCode)
 					{

--- a/BadgeUpClient/ResourceClients/AccountClient.cs
+++ b/BadgeUpClient/ResourceClients/AccountClient.cs
@@ -19,9 +19,9 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="id">A string that uniquely identifies this account</param>
 		/// <returns><see cref="AccountResponse"/></returns>
-		public async Task<AccountResponse> GetById(string id)
+		public Task<AccountResponse> GetById(string id)
 		{
-			return await this.m_httpClient.Get<AccountResponse>(ENDPOINT + "/" + id, "/v2");
+			return this.m_httpClient.Get<AccountResponse>(ENDPOINT + "/" + id, "/v2");
 		}
 	}
 }

--- a/BadgeUpClient/ResourceClients/AchievementClient.cs
+++ b/BadgeUpClient/ResourceClients/AchievementClient.cs
@@ -23,9 +23,9 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="id">A string that uniquely identifies this achievement</param>
 		/// <returns><see cref="AchievementResponse"/></returns>
-		public async Task<AchievementResponse> GetById(string id)
+		public Task<AchievementResponse> GetById(string id)
 		{
-			return await this.m_httpClient.Get<AchievementResponse>(ENDPOINT + "/" + id);
+			return this.m_httpClient.Get<AchievementResponse>(ENDPOINT + "/" + id);
 		}
 
 		/// <summary>
@@ -33,7 +33,7 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="achievement">The achievement to create.</param>
 		/// <returns>The created achievement.</returns>
-		public async Task<AchievementResponse> Create(Achievement achievement)
+		public Task<AchievementResponse> Create(Achievement achievement)
 		{
 			if (achievement == null)
 			{
@@ -41,17 +41,16 @@ namespace BadgeUp.ResourceClients
 			}
 
 			var request = new AchievementRequest(achievement);
-			var result = await this.m_httpClient.Post<AchievementResponse>(request, ENDPOINT);
-			return result;
+			return this.m_httpClient.Post<AchievementResponse>(request, ENDPOINT);
 		}
 
 		/// <summary>
 		/// Retrieves a list of all achievements.
 		/// </summary>
 		/// <returns>The list of all achievements.</returns>
-		public async Task<List<AchievementResponse>> GetAll()
+		public Task<List<AchievementResponse>> GetAll()
 		{
-			return await this.m_httpClient.GetAll<AchievementResponse>(ENDPOINT);
+			return this.m_httpClient.GetAll<AchievementResponse>(ENDPOINT);
 		}
 
 		/// <summary>
@@ -59,18 +58,19 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="achievementId">Unique achievement ID.</param>
 		/// <returns></returns>
-		public async Task<List<CriterionResponse>> GetAchievementCriteria(string achievementId)
+		public Task<List<CriterionResponse>> GetAchievementCriteria(string achievementId)
 		{
-			return await this.m_httpClient.GetAll<CriterionResponse>(ENDPOINT + "/" + achievementId + "/criteria");
+			return this.m_httpClient.GetAll<CriterionResponse>(ENDPOINT + "/" + achievementId + "/criteria");
 		}
+
 		/// <summary>
 		/// Retrieves a list of awards associated with an achievement.
 		/// </summary>
 		/// <param name="achievementId">Unique achievement ID.</param>
 		/// <returns></returns>
-		public async Task<List<AwardResponse>> GetAchievementAwards(string achievementId)
+		public Task<List<AwardResponse>> GetAchievementAwards(string achievementId)
 		{
-			return await this.m_httpClient.GetAll<AwardResponse>(ENDPOINT + "/" + achievementId + "/awards");
+			return this.m_httpClient.GetAll<AwardResponse>(ENDPOINT + "/" + achievementId + "/awards");
 		}
 	}
 }

--- a/BadgeUpClient/ResourceClients/AchievementIconClient.cs
+++ b/BadgeUpClient/ResourceClients/AchievementIconClient.cs
@@ -18,9 +18,9 @@ namespace BadgeUp.ResourceClients
 		/// Retrieves all uploaded achievement icons
 		/// </summary>
 		/// <returns><see cref="AchievementIconResponse"/></returns>
-		public async Task<AchievementIconResponse[]> GetAll()
+		public Task<AchievementIconResponse[]> GetAll()
 		{
-			return await this.m_httpClient.Get<AchievementIconResponse[]>(ENDPOINT);
+			return this.m_httpClient.Get<AchievementIconResponse[]>(ENDPOINT);
 		}
 	}
 }

--- a/BadgeUpClient/ResourceClients/ApplicationClient.cs
+++ b/BadgeUpClient/ResourceClients/ApplicationClient.cs
@@ -19,9 +19,9 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="id">A string that uniquely identifies this application</param>
 		/// <returns><see cref="ApplicationResponse"/></returns>
-		public async Task<ApplicationResponse> GetById(string id)
+		public Task<ApplicationResponse> GetById(string id)
 		{
-			return await this.m_httpClient.Get<ApplicationResponse>(ENDPOINT + "/" + id, "");
+			return this.m_httpClient.Get<ApplicationResponse>(ENDPOINT + "/" + id, "");
 		}
 	}
 }

--- a/BadgeUpClient/ResourceClients/AwardClient.cs
+++ b/BadgeUpClient/ResourceClients/AwardClient.cs
@@ -23,25 +23,25 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="id">A string that uniquely identifies this award</param>
 		/// <returns><see cref="AwardResponse"/></returns>
-		public async Task<AwardResponse> GetById(string id)
+		public Task<AwardResponse> GetById(string id)
 		{
-			return await this.m_httpClient.Get<AwardResponse>(ENDPOINT + "/" + id);
+			return this.m_httpClient.Get<AwardResponse>(ENDPOINT + "/" + id);
 		}
 
 		/// <summary>
 		/// Retrieves a list of all awards.
 		/// </summary>
 		/// <returns></returns>
-		public async Task<List<AwardResponse>> GetAll()
+		public Task<List<AwardResponse>> GetAll()
 		{
-			return await this.m_httpClient.GetAll<AwardResponse>(ENDPOINT);
+			return this.m_httpClient.GetAll<AwardResponse>(ENDPOINT);
 		}
 
 		/// <summary>
 		/// Retrieves a list of all awards.
 		/// </summary>
 		/// <returns></returns>
-		public async Task<AwardResponse> Create(Award award)
+		public Task<AwardResponse> Create(Award award)
 		{
 			if (award == null)
 			{
@@ -49,7 +49,7 @@ namespace BadgeUp.ResourceClients
 			}
 
 			var request = new AwardRequest(award);
-			return await this.m_httpClient.Post<AwardResponse>(request, ENDPOINT);
+			return this.m_httpClient.Post<AwardResponse>(request, ENDPOINT);
 		}
 	}
 }

--- a/BadgeUpClient/ResourceClients/CriterionClient.cs
+++ b/BadgeUpClient/ResourceClients/CriterionClient.cs
@@ -23,18 +23,18 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="id">A string that uniquely identifies this criterion</param>
 		/// <returns><see cref="CriterionResponse"/></returns>
-		public async Task<CriterionResponse> GetById(string id)
+		public Task<CriterionResponse> GetById(string id)
 		{
-			return await this.m_httpClient.Get<CriterionResponse>(ENDPOINT + "/" + id);
+			return this.m_httpClient.Get<CriterionResponse>(ENDPOINT + "/" + id);
 		}
 
 		/// <summary>
 		/// Retrieves a list of all criteria.
 		/// </summary>
 		/// <returns>The list of all criteria.</returns>
-		public async Task<List<CriterionResponse>> GetAll()
+		public Task<List<CriterionResponse>> GetAll()
 		{
-			return await this.m_httpClient.GetAll<CriterionResponse>(ENDPOINT);
+			return this.m_httpClient.GetAll<CriterionResponse>(ENDPOINT);
 		}
 
 		/// <summary>
@@ -42,7 +42,7 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="criterion">The criterion to create.</param>
 		/// <returns>The created criterion.</returns>
-		public async Task<CriterionResponse> Create(Criterion criterion)
+		public Task<CriterionResponse> Create(Criterion criterion)
 		{
 			if (criterion == null)
 			{
@@ -50,8 +50,7 @@ namespace BadgeUp.ResourceClients
 			}
 
 			var request = new CriterionRequest(criterion);
-			var result = await this.m_httpClient.Post<CriterionResponse>(request, ENDPOINT);
-			return result;
+			return this.m_httpClient.Post<CriterionResponse>(request, ENDPOINT);
 		}
 	}
 }

--- a/BadgeUpClient/ResourceClients/EarnedAchievementClient.cs
+++ b/BadgeUpClient/ResourceClients/EarnedAchievementClient.cs
@@ -23,9 +23,9 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="id">A string that uniquely identifies this achievement</param>
 		/// <returns><see cref="EarnedAchievementResponse"/></returns>
-		public async Task<EarnedAchievementResponse> GetById(string id)
+		public Task<EarnedAchievementResponse> GetById(string id)
 		{
-			return await this.m_httpClient.Get<EarnedAchievementResponse>(ENDPOINT + "/" + id);
+			return this.m_httpClient.Get<EarnedAchievementResponse>(ENDPOINT + "/" + id);
 		}
 
 		/// <summary>
@@ -33,10 +33,9 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="param">Optional QueryParams object, to filter the earned achievements by AchievementId, Subject, Since and Until parameters </param>
 		/// <returns><see cref="EarnedAchievementResponse"/></returns>
-		public async Task<List<EarnedAchievementResponse>> GetAll(EarnedAchievementQueryParams param = null)
+		public Task<List<EarnedAchievementResponse>> GetAll(EarnedAchievementQueryParams param = null)
 		{
-			return await this.m_httpClient.GetAll<EarnedAchievementResponse>(ENDPOINT, query: param?.ToQueryString());
+			return this.m_httpClient.GetAll<EarnedAchievementResponse>(ENDPOINT, query: param?.ToQueryString());
 		}
-
 	}
 }

--- a/BadgeUpClient/ResourceClients/EarnedAwardClient.cs
+++ b/BadgeUpClient/ResourceClients/EarnedAwardClient.cs
@@ -23,9 +23,9 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="id">A string that uniquely identifies this award</param>
 		/// <returns><see cref="EarnedAwardResponse"/></returns>
-		public async Task<EarnedAwardResponse> GetById(string id)
+		public Task<EarnedAwardResponse> GetById(string id)
 		{
-			return await this.m_httpClient.Get<EarnedAwardResponse>(ENDPOINT + "/" + id);
+			return this.m_httpClient.Get<EarnedAwardResponse>(ENDPOINT + "/" + id);
 		}
 
 		/// <summary>
@@ -33,9 +33,9 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="param">Optional QueryParams object, to filter the earned awards by AwardId, EarnedAchievementId, Subject, Since and Until parameters</param>
 		/// <returns><see cref="EarnedAwardResponse"/></returns>
-		public async Task<List<EarnedAwardResponse>> GetAll(EarnedAwardQueryParams param = null)
+		public Task<List<EarnedAwardResponse>> GetAll(EarnedAwardQueryParams param = null)
 		{
-			return await this.m_httpClient.GetAll<EarnedAwardResponse>(ENDPOINT, query: param?.ToQueryString());
+			return this.m_httpClient.GetAll<EarnedAwardResponse>(ENDPOINT, query: param?.ToQueryString());
 		}
 
 		public async Task<EarnedAwardResponse> ChangeState(string id, EarnedAwardState state)

--- a/BadgeUpClient/ResourceClients/MetricClient.cs
+++ b/BadgeUpClient/ResourceClients/MetricClient.cs
@@ -25,18 +25,18 @@ namespace BadgeUp.ResourceClients
 		/// <param name="subjectId">Unique subject the metrics is associated with</param>
 		/// <param name="key">Unique metric key the subject's metric is associated with</param>
 		/// <returns><see cref="MetricResponse"/></returns>
-		public async Task<MetricResponse> GetIndividualBySubject(string subjectId, string key)
+		public Task<MetricResponse> GetIndividualBySubject(string subjectId, string key)
 		{
-			return await this.m_httpClient.Get<MetricResponse>(ENDPOINT + "/" + subjectId.UrlEncode() + "/" + key.UrlEncode());
+			return this.m_httpClient.Get<MetricResponse>(ENDPOINT + "/" + subjectId.UrlEncode() + "/" + key.UrlEncode());
 		}
 
 		/// <summary>
 		/// Retrieves a list of all metrics.
 		/// </summary>
 		/// <returns></returns>
-		public async Task<List<MetricResponse>> GetAll()
+		public Task<List<MetricResponse>> GetAll()
 		{
-			return await this.m_httpClient.GetAll<MetricResponse>(ENDPOINT);
+			return this.m_httpClient.GetAll<MetricResponse>(ENDPOINT);
 		}
 
 		/// <summary>
@@ -44,9 +44,9 @@ namespace BadgeUp.ResourceClients
 		/// </summary>
 		/// <param name="subjectId">Unique subject the metrics is associated with.</param>
 		/// <returns></returns>
-		public async Task<List<MetricResponse>> GetAllBySubject(string subjectId)
+		public Task<List<MetricResponse>> GetAllBySubject(string subjectId)
 		{
-			return await this.m_httpClient.GetAll<MetricResponse>(ENDPOINT + "/" + subjectId.UrlEncode());
+			return this.m_httpClient.GetAll<MetricResponse>(ENDPOINT + "/" + subjectId.UrlEncode());
 		}
 
 		/// <summary>
@@ -56,7 +56,7 @@ namespace BadgeUp.ResourceClients
 		/// <param name="subject">Identifies the subject this metric is for. This would commonly be a unique user identifier.</param>
 		/// <param name="value">Value of this metric.</param>
 		/// <returns></returns>
-		public async Task<MetricResponse> Create(Metric metric)
+		public Task<MetricResponse> Create(Metric metric)
 		{
 			if (metric == null)
 			{
@@ -65,7 +65,7 @@ namespace BadgeUp.ResourceClients
 
 			var request = new MetricRequest(metric);
 
-			return await this.m_httpClient.Post<MetricResponse>(request, ENDPOINT + "/" + metric.Subject.UrlEncode());
+			return this.m_httpClient.Post<MetricResponse>(request, ENDPOINT + "/" + metric.Subject.UrlEncode());
 		}
 	}
 }

--- a/BadgeUpClient/ResourceClients/ProgressClient.cs
+++ b/BadgeUpClient/ResourceClients/ProgressClient.cs
@@ -24,7 +24,7 @@ namespace BadgeUp.ResourceClients
 		/// <param name="includeCriteria">Include related criteria</param>
 		/// <param name="includeAwards">Include related awards</param>
 		/// <returns></returns>
-		public async Task<List<Progress>> GetProgress(string subjectId, bool includeAchievements = false, bool includeCriteria = false, bool includeAwards = false)
+		public Task<List<Progress>> GetProgress(string subjectId, bool includeAchievements = false, bool includeCriteria = false, bool includeAwards = false)
 		{
 			var query = new HttpQuery();
 			query.Add("subject", subjectId);
@@ -38,7 +38,7 @@ namespace BadgeUp.ResourceClients
 				query.Add("include", "criterion");
 			if (includeAwards)
 				query.Add("include", "award");
-			return await this.m_httpClient.GetAll<Progress>(ENDPOINT, query:query.ToString());
+			return this.m_httpClient.GetAll<Progress>(ENDPOINT, query:query.ToString());
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Install the package [from nuget here](https://www.nuget.org/packages/BadgeUpClie
 ### Example Use
 The BadgeUp .NET client is initialized with an API key which can be generated in the BadgeUp dashboard.
 ```cs
-using BadgeUpClient.Types;
-using BadgeUpClient.Responses;
+using BadgeUp;
+using BadgeUp.Responses;
+using BadgeUp.Types;
+using System;
 
 // instantiate the client
-var badgeup = new BadgeUpClient("<api key here>");
+var client = new BadgeUpClient("<api key here>");
 
 // create an event
 var badgeupEvent = new Event("some_user", "jump", new Modifier { Inc = 1 });
@@ -25,29 +27,32 @@ var badgeupEvent = new Event("some_user", "jump", new Modifier { Inc = 1 });
 badgeupEvent.Timestamp = DateTimeOffset.Parse("2017-01-01T18:00:00+05:30");
 
 //send an event
-EventResponse response = await badgeup.Event.Send(badgeupEvent);
+EventResponse response = await client.Event.Send(badgeupEvent);
 
 // loop through all the progress results
-foreach (var prog in response.Progress)
+foreach (var eventResult in response.Results)
 {
-    // check if this is a newly-earned achievement
-    if (prog.IsComplete && prog.IsNew)
+    foreach (var prog in eventResult.Progress)
     {
-        string earnedAchievementId = prog.EarnedAchievementId;
-        string achievementId = prog.AchievementId;
-        System.Console.WriteLine($"Achievement with ID {prog.AchievementId} Earned!");
-
-        // from here you can use AchievementId and EarnedAchievementId to get the original achievement and awards objects
-        var earnedAchievement = await client.EarnedAchievement.GetById(earnedAchievementId);
-        var achievement = await client.Achievement.GetById(achievementId);
-
-        // get associated award information
-        foreach (var awardId in achievement.Awards)
+        // check if this is a newly-earned achievement
+        if (prog.IsComplete && prog.IsNew)
         {
-            var award = await client.Award.GetById(awardId);
-            // in the dashboard set the award to `{ "points": 5 }`
-            int points = award.Data["points"].ToObject<int>();
-            System.Console.WriteLine($"Points awarded: {points}");
+            string earnedAchievementId = prog.EarnedAchievementId;
+            string achievementId = prog.AchievementId;
+            System.Console.WriteLine($"Achievement with ID {prog.AchievementId} Earned!");
+
+            // from here you can use AchievementId and EarnedAchievementId to get the original achievement and awards objects
+            var earnedAchievement = await client.EarnedAchievement.GetById(earnedAchievementId);
+            var achievement = await client.Achievement.GetById(achievementId);
+
+            // get associated award information
+            foreach (var awardId in achievement.Awards)
+            {
+                var award = await client.Award.GetById(awardId);
+                // in the dashboard set the award to `{ "points": 5 }`
+                int points = award.Data["points"].ToObject<int>();
+                System.Console.WriteLine($"Points awarded: {points}");
+            }
         }
     }
 }


### PR DESCRIPTION
* Remove redundant async/await calls in resource clients and return Task instead.
* Call `.ConfigureAwait(false)` on HttpClient tasks as per [.NET library guidelines](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx). This prevents deadlocks in certain scenarios on UI and server applications.